### PR TITLE
Reduce Errors Logged For No Status Info

### DIFF
--- a/UnifiedThermostat/UnifiedThermostatParent_Driver.groovy
+++ b/UnifiedThermostat/UnifiedThermostatParent_Driver.groovy
@@ -29,6 +29,7 @@
  *    2023-01-07  Simon Burke    1.0.30   Now use JsonOutput for larger HTTP response logging
                                           Automatically turn off Debug Logging after 30 minutes
  *    2023-01-09  Simon Burke    1.0.31   Detection of A/C Units configured under Floors and Areas in MELCloud
+ *    2023-04-02  Simon Burke    1.0.32   Updated applyStatusUpdates in child driver to detect when no status data is available
  */
 
 import groovy.json.JsonOutput;

--- a/UnifiedThermostat/UnifiedThermostatUnitChild_Driver.groovy
+++ b/UnifiedThermostat/UnifiedThermostatUnitChild_Driver.groovy
@@ -714,9 +714,9 @@ def retrieveStatusInfo_MELCloud() {
 def applyStatusUpdates(statusInfo) {
     def statusIsCurrent = 1
     parent.debugLog("applyResponseStatus: Status Info: ${statusInfo}")
-    // Check to make sure the status map is not empty and that we have at least the status as at date, as an indicator there are likely some
+    // Check to make sure the status map is not empty and that we have at least the unitId, as an indicator there are likely some
     //   status updates available
-    if (!statusInfo.isEmpty() && statusInfo.statusAsAt != null) {
+    if (!statusInfo.isEmpty() && statusInfo.unitId != null) {
         parent.debugLog("applyResponseStatus: lastCommandUTC = ${checkNull(device.currentValue("lastCommandUTC", true),"Null")}, ${checkNull(statusInfo.statusAsAt,"Null")}")
         if (device.currentValue("lastCommandUTC") != null && statusInfo.containsKey("statusAsAt") ) {
             

--- a/UnifiedThermostat/UnifiedThermostatUnitChild_Driver.groovy
+++ b/UnifiedThermostat/UnifiedThermostatUnitChild_Driver.groovy
@@ -52,6 +52,8 @@
  *    2023-01-07  Alexander Laamanen 1.0.29 MELCloud - Fixes to handle multiple AC Units in MELCloud setup
  *    2023-01-07  Simon Burke    1.0.30   Now use JsonOutput for larger HTTP response logging
                                           Automatically turn off Debug Logging after 30 minutes
+ *    2023-01-09  Simon Burke    1.0.31   Detection of A/C Units configured under Floors and Areas in MELCloud
+ *    2023-04-02  Simon Burke    1.0.32   Updated applyStatusUpdates in child driver to detect when no status data is available
  */
 import java.text.DecimalFormat;
 import groovy.json.JsonOutput;
@@ -712,8 +714,9 @@ def retrieveStatusInfo_MELCloud() {
 def applyStatusUpdates(statusInfo) {
     def statusIsCurrent = 1
     parent.debugLog("applyResponseStatus: Status Info: ${statusInfo}")
-    
-    if (!statusInfo.isEmpty()) {
+    // Check to make sure the status map is not empty and that we have at least the status as at date, as an indicator there are likely some
+    //   status updates available
+    if (!statusInfo.isEmpty() && statusInfo.statusAsAt != null) {
         parent.debugLog("applyResponseStatus: lastCommandUTC = ${checkNull(device.currentValue("lastCommandUTC", true),"Null")}, ${checkNull(statusInfo.statusAsAt,"Null")}")
         if (device.currentValue("lastCommandUTC") != null && statusInfo.containsKey("statusAsAt") ) {
             

--- a/UnifiedThermostat/packageManifest.json
+++ b/UnifiedThermostat/packageManifest.json
@@ -2,11 +2,11 @@
 	"packageName": "Unified Thermostat",
 	"minimumHEVersion": "2.2.1",
 	"author": "Simon Burke (sburke781)",
-	"version": "1.0.31",
-	"dateReleased": "2023-01-09",
+	"version": "1.0.32",
+	"dateReleased": "2023-04-02",
 	"documentationLink": "https://github.com/sburke781/hubitat/blob/master/UnifiedThermostat/Readme.md",
 	"communityLink": "https://community.hubitat.com/t/release-unified-thermostat-driver-alpha-melcloud-melview-kumo-cloud-and-more-if-you-want",
-	"releaseNotes": "2023-01-09: 1.0.31 - Detection of MELCloud units on Floors and Areas\n2023-01-07: 1.0.30 - Now use JsonOutput for larger HTTP response logging, automatically turn off Debug Logging after 30 minutes\n2023-01-07: 1.0.29 - MELCloud Fixes to handle multiple AC Units (@klaamane)\n2022-12-11: 1.0.28 - Include MELCloud's Power reading of true in thermostat operating state detection\n2022-12-11: 1.0.27 - Changes to setHeatingSetpoint and setCoolingSetpoint to use thermostatMode rather than thermostatOperatingState when determining whether to send command to the platform",
+	"releaseNotes": "2023-04-02: 1.0.32 - Updated applyStatusUpdates in child driver to detect when no status data is available\n2023-01-09: 1.0.31 - Detection of MELCloud units on Floors and Areas\n2023-01-07: 1.0.30 - Now use JsonOutput for larger HTTP response logging, automatically turn off Debug Logging after 30 minutes\n2023-01-07: 1.0.29 - MELCloud Fixes to handle multiple AC Units (@klaamane)\n2022-12-11: 1.0.28 - Include MELCloud's Power reading of true in thermostat operating state detection\n2022-12-11: 1.0.27 - Changes to setHeatingSetpoint and setCoolingSetpoint to use thermostatMode rather than thermostatOperatingState when determining whether to send command to the platform",
 	"apps" : [],
 	"drivers" : [
 		{


### PR DESCRIPTION
Add check when attempting to apply status updates to identify when the status check failed and no status info is present, reducing logs from child driver when this happens.