### PR TITLE
Fix for missed radar images

### DIFF
--- a/BoMWeather/RadarImages/BoMRadarImagesDataFile_Driver.groovy
+++ b/BoMWeather/RadarImages/BoMRadarImagesDataFile_Driver.groovy
@@ -109,7 +109,7 @@ void retrieveImageURLsCallback(resp, data) {
             String imagesJson = '{\n'
             int i = 1
             images.each {
-                imagesJson += "\"image${i}\": \"http://www.bom.gov.au/radar/${it.value.toString().substring(32).substring(0,it.value.toString().substring(32).length() - 7)}\"";
+                imagesJson += "\"image${i}\": \"http://www.bom.gov.au/radar/${it.substring(32).substring(0,it.substring(32).length() - 7)}\"";
                 if (i != images.size()) { imagesJson += ',' }
                 imagesJson += '\n'
                 i++

--- a/BoMWeather/RadarImages/packageManifest.json
+++ b/BoMWeather/RadarImages/packageManifest.json
@@ -2,11 +2,11 @@
 	"packageName": "BoM Weather Radar Images",
 	"minimumHEVersion": "2.2.9.141",
 	"author": "Simon Burke (sburke781)",
-	"version": "1.2.0",
-	"dateReleased": "2021-12-28",
+	"version": "1.2.1",
+	"dateReleased": "2024-04-13",
 	"documentationLink": "",
 	"communityLink": "https://community.hubitat.com/t/release-australian-bureau-of-meteorology-data-radar-images-data-file/82637",
-	"releaseNotes": "2021-12-28: 1.2.0 - HTTP calls changes to Asynchronous\n2021-11-25: 1.1.0 - Changed Locations and Range images to the foreground\n2021-11-23: 1.0.0 - Stable Release with addition of options for Locations, Topography and Range backgrounds\n2021-11-06: 0.1.2 - Alpha release",
+	"releaseNotes": "2024-04-13 1.2.1 - Fix for missed radar images\n2021-12-28: 1.2.0 - HTTP calls changes to Asynchronous\n2021-11-25: 1.1.0 - Changed Locations and Range images to the foreground\n2021-11-23: 1.0.0 - Stable Release with addition of options for Locations, Topography and Range backgrounds\n2021-11-06: 0.1.2 - Alpha release",
 	"apps" : [],
 	"drivers" : [
 		{


### PR DESCRIPTION
Fix to radar images parsing to remove the ".value.toString()" from code after it produced incorrect image links in recent times.